### PR TITLE
added readthedocs.yml, so python 3.6 will be used for building the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - python -m pip install -U -r requirements_dev.txt
         - python setup.py install
       script:
-        - cd docs; make clean_all api_docs html linkcheck
+        - cd docs; make clean_all html linkcheck
       after_success:
         # this prevents the tests to upload stuff to coveralls.io
         - echo "done"

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,6 @@
+build:
+  image: latest
+
+python:
+  version: 3.6
+  setup_py_install: true


### PR DESCRIPTION
* Added a  [``readthedocs.yml``](https://docs.readthedocs.io/en/latest/yaml-config.html) so readthedocs uses python 3.6 to build the documentation.
* Since when changing the API, ``make api_docs`` needs to be called to update the list of packages which should be documented, having ``api_docs`` in ``tests-doc-creation`` could lead to a false positiv test result 

**Closing issues**

closes #21 