### PR TITLE
refactored tests to reduce code overhead

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,22 @@
+import math
+import numpy as np
+
+
+def assert_epsilon(wanted_value, given_value):
+    """
+    Test helper function to assert, if not all values of wanted_value and given_value
+    are smaller than epsilon.
+    Epsilon is 3 orders of magnitude smaller than the minimum of the absolute
+    values of  wanted_value.
+
+    Parameters
+    ----------
+    wanted_value: np.array, float, int
+        Wanted value
+    given_value: np.array, float, int
+        Given Value
+    """
+    min_want = np.min(np.abs(wanted_value))
+    epsilon = 10**(math.floor(math.log10(min_want)) - 3)
+    msg = 'Want: {} Have: {} with epsilon {}'.format(wanted_value, given_value, epsilon)
+    assert np.any(np.abs(wanted_value - given_value) < epsilon), msg

--- a/tests/test_simple_kinetic_model.py
+++ b/tests/test_simple_kinetic_model.py
@@ -1,8 +1,9 @@
-import math
-from unittest import TestCase
-from lmfit_varpro import SeparableModel
 from lmfit import Parameters
 import numpy as np
+import pytest
+
+from lmfit_varpro import SeparableModel
+from .test_helpers import assert_epsilon
 
 
 class OneCompartmentDecay(SeparableModel):
@@ -13,12 +14,24 @@ class OneCompartmentDecay(SeparableModel):
 
     def c_matrix(self, parameter, *args, **kwargs):
         parameter = parameter.valuesdict()
-        kinpar = np.asarray([parameter["p0"]])
-        c = np.exp(np.outer(np.asarray(kwargs['times']), -kinpar))
+        kinpar = np.array([parameter["p0"]])
+        c = np.exp(np.outer(np.array(kwargs['times']), -kinpar))
         return [c]
 
     def e_matrix(self, parameter, **kwargs):
-        return np.asarray([[1.0]])
+        return np.array([[1.0]])
+
+    def get_test_param_dict(self):
+        rparams = [101e-4]
+        params = [100e-5]
+        wanted_e_matrix = [1.0]
+        result_is_e_matrix = True
+        test_param_dict = {"rparams": rparams,
+                           "params": params,
+                           "wanted_params": rparams,
+                           "wanted_e_matrix": wanted_e_matrix,
+                           "result_is_e_matrix": result_is_e_matrix}
+        return test_param_dict
 
 
 class TwoComparmentDecay(SeparableModel):
@@ -28,17 +41,29 @@ class TwoComparmentDecay(SeparableModel):
         return data
 
     def c_matrix(self, parameter, *args, **kwargs):
-        kinpar = np.asarray([parameter["p0"], parameter["p1"]])
+        kinpar = np.array([parameter["p0"], parameter["p1"]])
         c = np.exp(np.outer(kwargs['times'], -kinpar))
         return [c]
 
     def e_matrix(self, parameter, **kwargs):
-        return np.asarray([[1.0, 2.0]])
+        return np.array([[1.0, 2.0]])
+
+    def get_test_param_dict(self):
+        rparams = [101e-4, 202e-5]
+        params = [100e-5, 200e-6]
+        wanted_e_matrix = [1.0, 2.0]
+        result_is_e_matrix = True
+        test_param_dict = {"rparams": rparams,
+                           "params": params,
+                           "wanted_params": rparams,
+                           "wanted_e_matrix": wanted_e_matrix,
+                           "result_is_e_matrix": result_is_e_matrix}
+        return test_param_dict
 
 
 class MultiChannelMultiCompartmentDecay(SeparableModel):
 
-    wavenum = np.asarray(np.arange(12820, 15120, 4.6))
+    wavenum = np.arange(12820, 15120, 4.6)
 
     def data(self, **kwargs):
         data = [kwargs['data'][i, :] for i in
@@ -46,16 +71,16 @@ class MultiChannelMultiCompartmentDecay(SeparableModel):
         return data
 
     def c_matrix(self, parameter, *args, **kwargs):
-        kinpar = np.asarray([parameter["p{}".format(i)] for i in
-                             range(len((parameter)))])
+        kinpar = np.array([parameter["p{}".format(i)] for i in
+                           range(len((parameter)))])
         c = np.exp(np.outer(kwargs['times'], -kinpar))
         return [c for _ in range(self.wavenum.shape[0])]
 
     def e_matrix(self, parameter, **kwargs):
-        location = np.asarray(
+        location = np.array(
             [14705, 13513, 14492, 14388, 14184, 13986])
-        delta = np.asarray([400, 1000, 300, 200, 350, 330])
-        amp = np.asarray([1, 0.1, 10, 100, 1000, 10000])
+        delta = np.array([400, 1000, 300, 200, 350, 330])
+        amp = np.array([1, 0.1, 10, 100, 1000, 10000])
 
         E = np.empty((self.wavenum.shape[0], location.shape[0]),
                      dtype=np.float64,
@@ -69,97 +94,58 @@ class MultiChannelMultiCompartmentDecay(SeparableModel):
             )
         return E
 
-
-class TestSimpleKinetic(TestCase):
-
-    def assertEpsilon(self, number, value):
-        epsilon = 10**(math.floor(math.log10(abs(number))) - 3)
-        self.assertTrue(abs(number - value) < epsilon,
-                        msg='Want: {} Have: {} with epsilon {}'
-                            ''.format(number, value, epsilon))
-
-    def test_one_compartment_decay(self):
-
-        model = OneCompartmentDecay()
-        times = np.asarray(np.arange(0, 1000, 1.5))
-
-        params = [101e-4]
-
-        real_params = Parameters()
-        for i in range(len(params)):
-            real_params.add("p{}".format(i), params[i])
-        data = model.eval(real_params, **{"times": times})
-
-        initial_parameter = Parameters()
-        initial_parameter.add("p0", 100e-5)
-
-        result = model.fit(initial_parameter, False, [], **{"times": times,
-                                                            "data": data})
-        for i in range(len(params)):
-            self.assertEpsilon(params[i],
-                               result.best_fit_parameter["p{}".format(i)].value)
-        amps = result.e_matrix(data, **{"times": times, "data": data})
-        print(amps)
-        self.assertEpsilon(amps[0], 1.0)
-
-    def test_two_compartment_decay(self):
-
-        model = TwoComparmentDecay()
-        times = np.asarray(np.arange(0, 1500, 1.5))
-
-        params = [101e-4, 202e-5]
-
-        real_params = Parameters()
-        for i in range(len(params)):
-            real_params.add("p{}".format(i), params[i])
-
-        data = model.eval(real_params, **{"times": times})
-
-        initial_parameter = Parameters()
-        initial_parameter.add("p0", 100e-5)
-        initial_parameter.add("p1", 200e-6)
-
-        result = model.fit(initial_parameter, False, [], **{"times": times,
-                                                            "data": data})
-        for i in range(len(params)):
-            self.assertEpsilon(params[i],
-                               result.best_fit_parameter["p{}".format(i)]
-                               .value)
-        amps = result.e_matrix(data, **{"times": times, "data": data})[0]
-        print(amps)
-        want = [1.0, 2.0]
-        for i in range(len(want)):
-            self.assertEpsilon(amps[i], want[i])
-
-    def test_multi_compartment_multi_channel_decay(self):
-
-        model = MultiChannelMultiCompartmentDecay()
-        times = np.asarray(np.arange(0, 1500, 1.5))
-
+    def get_test_param_dict(self):
         rparams = [.006667, .006667, 0.00333, 0.00035, 0.0303, 0.000909]
-
-        real_params = Parameters()
-        for i in range(len(rparams)):
-            real_params.add("p{}".format(i), rparams[i])
-
-        data = model.eval(real_params, **{"times": times})
-
         params = [.005, 0.003, 0.00022, 0.0300, 0.000888]
-        initial_parameter = Parameters()
-        for i in range(len(params)):
-            initial_parameter.add("p{}".format(i), params[i])
-
-        result = model.fit(initial_parameter, False, [], **{"times": times,
-                                                            "data": data})
-
         wanted_params = [.006667, 0.00333, 0.00035, 0.0303, 0.000909]
-        for i in range(len(wanted_params)):
-            self.assertEpsilon(wanted_params[i],
-                               result.best_fit_parameter["p{}".format(i)]
-                               .value)
+        result_is_e_matrix = False
+        test_param_dict = {"rparams": rparams,
+                           "params": params,
+                           "wanted_params": wanted_params,
+                           "result_is_e_matrix": result_is_e_matrix}
+        return test_param_dict
 
-        fitted = result.eval(**{"times": times, "data": data})
 
-        for i in range(fitted.shape[0]):
-            for j in range(fitted.shape[1]):
-                self.assertEpsilon(data[i, j], fitted[i, j])
+@pytest.mark.parametrize("compartment_decay_model",
+                         [
+                             TwoComparmentDecay,
+                             OneCompartmentDecay,
+                             MultiChannelMultiCompartmentDecay
+                          ])
+def test_compartment_decay(compartment_decay_model):
+
+    model = compartment_decay_model()
+    times = np.arange(0, 1500, 1.5)
+
+    test_param_dict = model.get_test_param_dict()
+
+    rparams = test_param_dict["rparams"]
+
+    real_params = Parameters()
+    for index, rparam in enumerate(rparams):
+        real_params.add("p{}".format(index), rparam)
+
+    data = model.eval(real_params, times=times)
+
+    params = test_param_dict["params"]
+
+    initial_parameter = Parameters()
+    for index, param in enumerate(params):
+        initial_parameter.add("p{}".format(index), param)
+
+    result = model.fit(initial_parameter, False, [], times=times, data=data)
+
+    wanted_params = test_param_dict["wanted_params"]
+
+    for index, wanted_param in enumerate(wanted_params):
+        fit_value = result.best_fit_parameter["p{}".format(index)].value
+        assert_epsilon(wanted_param, fit_value)
+
+    if test_param_dict["result_is_e_matrix"]:
+        wanted_e_matrix = test_param_dict["wanted_e_matrix"]
+        amplitudes = result.e_matrix(data, times=times, data=data)[0]
+        for amplitude, want in zip(amplitudes, wanted_e_matrix):
+            assert_epsilon(amplitude, want)
+    else:
+        fitted = result.eval(times=times, data=data)
+        assert_epsilon(data, fitted)


### PR DESCRIPTION
* Moved ``assert_epsilon`` since its not speciffic to this tests and can be reused 
* Used vecorized calculation (numpy) in ``assert_epsilon``, which increases the speed of the tests by a factor of 2
* Reduced the 3 tests to a single one using ``@pytest.mark.parametrize``, reducing the code overhead
* Added the parameters to the models, since they are specific to the model not the tests

P.S.: The calculation of ``epsilon`` in  is still done by math and not numpy, since math is faster on scalar values [see](https://github.com/s-weigand/ipynb-share/blob/master/benchmarks/np%20vs.%20math.ipynb)

closes #23 